### PR TITLE
Rename local files/perf improvement

### DIFF
--- a/src/Git.Unite/Program.cs
+++ b/src/Git.Unite/Program.cs
@@ -16,10 +16,16 @@ namespace Git.Unite
             List<string> paths;
             var opts = new OptionSet
                 {
-                    {"dry-run", "dry run without making changes", v => options |= v != null ? GitUnite.OptionFlags.DryRun : options},
-                    {"d|directory-only", "only perform directory case changes", v => options = v != null ? options ^ GitUnite.OptionFlags.UniteFiles : options},
-                    {"f|file-only", "only perform filename case changes", v => options = v != null ? options ^ GitUnite.OptionFlags.UniteDirectories : options},
-                    {"h|help", "show this message and exit", v => showHelp = v != null}
+                    {"dry-run", "dry run without making changes",
+                        v => options  |= v != null ? GitUnite.OptionFlags.DryRun : options},
+                    {"d|directory-only", "only perform directory case changes",
+                        v => { if (v != null) options = (options & ~GitUnite.OptionFlags.UniteFiles      ) | GitUnite.OptionFlags.UniteDirectories;}},
+                    {"f|file-only", "only perform filename case changes",
+                        v => { if (v != null) options = (options & ~GitUnite.OptionFlags.UniteDirectories) | GitUnite.OptionFlags.UniteFiles      ;}},
+                    {"r|rename-local", "rename local files/directories to match the repo",
+                        v => options  |= v != null ? GitUnite.OptionFlags.RenameLocal : options}, 
+                    {"h|help", "show this message and exit",
+                        v => showHelp  = v != null}
                 };
 
             try

--- a/src/LibGitUnite/GitUnite.cs
+++ b/src/LibGitUnite/GitUnite.cs
@@ -24,10 +24,14 @@ namespace LibGitUnite
             /// <summary>
             /// Process filenames for case changes
             /// </summary>
-            UniteFiles = 4
+            UniteFiles = 4,
+            /// <summary>
+            /// Rename local directories/files instead of modifying index
+            /// </summary>
+            RenameLocal = 8,
         }
 
-        private const string Separator = "\\";
+        internal const string Separator = "\\";
 
         /// <summary>
         /// Unite the git repository index file paths with the same case the OS is using
@@ -63,11 +67,12 @@ namespace LibGitUnite
         {
             if (!folders.Any()) return;
 
+            var foldersFullPathMap = new HashSet<String>(folders.ConvertAll(s => s.FullName));
             // Find all repository files with directory paths not found in the host OS folder collection
             var indexEntries =
                 repo.Index.Where(f => f.Path.LastIndexOf(Separator, StringComparison.Ordinal) != -1
                                       &&
-                                      !folders.Any(s => s.FullName.Contains(f.Path.Substring(0, f.Path.LastIndexOf(Separator, StringComparison.Ordinal)))));
+                                      !foldersFullPathMap.Any(s => s.Contains(f.Path.Substring(0, f.Path.LastIndexOf(Separator, StringComparison.Ordinal)))));
 
             // Unite the casing of the repository file directory path with the casing seen by the host operating system
             foreach (var entry in indexEntries)

--- a/src/LibGitUnite/GitUnite.cs
+++ b/src/LibGitUnite/GitUnite.cs
@@ -67,7 +67,7 @@ namespace LibGitUnite
         {
             if (!folders.Any()) return;
 
-            var foldersFullPathMap = new HashSet<String>(folders.ConvertAll(s => s.FullName));
+            var foldersFullPathMap = new HashSet<String>(folders.Select(s => s.FullName));
             // Find all repository files with directory paths not found in the host OS folder collection
             var indexEntries =
                 repo.Index.Where(f => f.Path.LastIndexOf(Separator, StringComparison.Ordinal) != -1
@@ -101,8 +101,10 @@ namespace LibGitUnite
         /// <param name="folders"></param>
         private static void UniteFilenameCasing(this UniteRepository repo, DirectoryInfo gitPathInfo, List<DirectoryInfo> folders)
         {
-            var files = folders.GetAllFileInfos(gitPathInfo);
-            var indexFileEntries = repo.Index.Where(f => files.All(s => s.FullName.Replace(repo.Info.WorkingDirectory, string.Empty) != f.Path));
+            var files               = folders.GetAllFileInfos(gitPathInfo);
+            var filesName           = new HashSet<String>(files.Select(
+                s => s.FullName.Replace(repo.Info.WorkingDirectory, string.Empty)));
+            var indexFileEntries    = repo.Index.Where(f => !filesName.Contains(f.Path));
 
             foreach (var entry in indexFileEntries)
             {


### PR DESCRIPTION
Adds the ability to ensure local files match the git repo's listing. (Wrote this to solve an issue where the case changed w/ some files locally on win32 and it was crippling git's ability to display history for those files.)