### PR TITLE
Performance optimization and new option

### DIFF
--- a/src/Git.Unite/Program.cs
+++ b/src/Git.Unite/Program.cs
@@ -19,6 +19,7 @@ namespace Git.Unite
                     {"dry-run", "dry run without making changes", v => options |= v != null ? OptionFlags.DryRun : options},
                     {"d|directory-only", "only perform directory case changes", v => options = v != null ? options ^ OptionFlags.UniteFiles : options},
                     {"f|file-only", "only perform filename case changes", v => options = v != null ? options ^ OptionFlags.UniteDirectories : options},
+                    {"o|os-rename", "Rename files in host OS file system to make them as they are in git index", v => options = v != null ? options ^ OptionFlags.RenameEntriesInHostOS : options},
                     {"h|help", "show this message and exit", v => showHelp = v != null}
                 };
 

--- a/src/LibGitUnite/OptionFlags.cs
+++ b/src/LibGitUnite/OptionFlags.cs
@@ -19,6 +19,10 @@ namespace LibGitUnite
         /// <summary>
         /// Process filenames for case changes
         /// </summary>
-        UniteFiles = 4
+        UniteFiles = 4,
+        /// <summary>
+        /// Rename files in host OS file system to make them as they are in git index
+        /// </summary>
+        RenameEntriesInHostOS = 8
     }
 }

--- a/src/LibGitUnite/UniteRepository.cs
+++ b/src/LibGitUnite/UniteRepository.cs
@@ -237,11 +237,11 @@ namespace LibGitUnite
             var files = _gitDirectoryInfo.GetFiles("*", SearchOption.AllDirectories).Where(f => !GetFullName(f).StartsWith(dotGitFolderPath)).ToList();
             var filesFullPathMap = new HashSet<string>(files.ConvertAll(GetFullName));
             var strippedPathMap = new HashSet<string>(filesFullPathMap.Select(x => x.Replace(_gitRepository.Info.WorkingDirectory, string.Empty).ToString()));
-            var indexFileEntries = _gitRepository.Index.Where(f => strippedPathMap.All(s => s != f.Path));
-
+            var indexFileEntries = _gitRepository.Index.Select(x => x.Path).Except(strippedPathMap);
+            
             foreach (var entry in indexFileEntries)
             {
-                var sourcePath = _gitRepository.Info.WorkingDirectory + entry.Path;
+                var sourcePath = _gitRepository.Info.WorkingDirectory + entry;
 
                 // Match host OS filename based on full pathname ignoring case
                 var target = files.FirstOrDefault(f => string.Equals(GetFullName(f), sourcePath, StringComparison.CurrentCultureIgnoreCase));

--- a/src/LibGitUnite/UniteRepository.cs
+++ b/src/LibGitUnite/UniteRepository.cs
@@ -236,7 +236,8 @@ namespace LibGitUnite
             var dotGitFolderPath = Path.Combine(GetFullName(_gitDirectoryInfo), ".git", " ").TrimEnd();
             var files = _gitDirectoryInfo.GetFiles("*", SearchOption.AllDirectories).Where(f => !GetFullName(f).StartsWith(dotGitFolderPath)).ToList();
             var filesFullPathMap = new HashSet<string>(files.ConvertAll(GetFullName));
-            var indexFileEntries = _gitRepository.Index.Where(f => filesFullPathMap.All(s => s.Replace(_gitRepository.Info.WorkingDirectory, string.Empty) != f.Path));
+            var strippedPathMap = new HashSet<string>(filesFullPathMap.Select(x => x.Replace(_gitRepository.Info.WorkingDirectory, string.Empty).ToString()));
+            var indexFileEntries = _gitRepository.Index.Where(f => strippedPathMap.All(s => s != f.Path));
 
             foreach (var entry in indexFileEntries)
             {


### PR DESCRIPTION
Sometimes we have users, who have filenames in different case (from index) in their local copies. 
To find all files in wrong case, and make them as they are in index, I have added new option 'os-rename' - it doesn't make any changes in index, but rename files in filesystem.

And I also make some performance optimizations, it's good for big repositories. It gives about 10 times processing speed boost on my repository.